### PR TITLE
Apply inverse image scaling to ensure the WebView renders at 1:1

### DIFF
--- a/WebView.h
+++ b/WebView.h
@@ -39,4 +39,6 @@ private:
     Gfx::IntPoint to_content(Gfx::IntPoint) const;
 
     OwnPtr<HeadlessBrowserPageClient> m_page_client;
+
+    qreal m_inverse_pixel_scaling_ratio { 1.0 };
 };


### PR DESCRIPTION
On high-dpi systems QT will automatically scale up painting operations.
This results in an ugly blurry browser window surrounded by a nicely
scaled window frame. This patch applies an inverse scale to the WebView
widget, ensuring the painting and mouse events are lined up and draw
with a 1:1 pixel ratio with respect to the display's device pixels.