### PR TITLE
Trigger browser to quit when the main window is closed

### DIFF
--- a/BrowserWindow.cpp
+++ b/BrowserWindow.cpp
@@ -1,8 +1,10 @@
 #include "BrowserWindow.h"
 #include "WebView.h"
+#include <LibCore/EventLoop.h>
 #include <QStatusBar>
 
-BrowserWindow::BrowserWindow()
+BrowserWindow::BrowserWindow(Core::EventLoop& event_loop)
+    : m_event_loop(event_loop)
 {
     m_toolbar = new QToolBar;
     m_location_edit = new QLineEdit;
@@ -38,4 +40,14 @@ void BrowserWindow::page_title_changed(QString title)
 void BrowserWindow::page_favicon_changed(QIcon icon)
 {
     setWindowIcon(icon);
+}
+
+void BrowserWindow::closeEvent(QCloseEvent* event)
+{
+    QWidget::closeEvent(event);
+
+    // FIXME: Ladybird only supports one window at the moment. When we support
+    //        multiple windows, we'll only want to fire off the quit event when
+    //        all of the browser windows have closed.
+    m_event_loop.quit(0);
 }

--- a/BrowserWindow.h
+++ b/BrowserWindow.h
@@ -1,4 +1,5 @@
 #include <QIcon>
+#include <LibCore/Forward.h>
 #include <QLineEdit>
 #include <QMainWindow>
 #include <QToolBar>
@@ -10,9 +11,11 @@ class WebView;
 class BrowserWindow : public QMainWindow {
     Q_OBJECT
 public:
-    BrowserWindow();
+    explicit BrowserWindow(Core::EventLoop&);
 
     WebView& view() { return *m_view; }
+
+    virtual void closeEvent(QCloseEvent*) override;
 
 public slots:
     void location_edit_return_pressed();
@@ -23,4 +26,5 @@ private:
     QToolBar* m_toolbar { nullptr };
     QLineEdit* m_location_edit { nullptr };
     WebView* m_view { nullptr };
+    Core::EventLoop& m_event_loop;
 };

--- a/main.cpp
+++ b/main.cpp
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Core::EventLoop event_loop;
 
     QApplication app(arguments.argc, arguments.argv);
-    BrowserWindow window;
+    BrowserWindow window(event_loop);
     window.setWindowTitle("Ladybird");
     window.resize(800, 600);
     window.show();


### PR DESCRIPTION
This patch adds an event handler to the main window which allows it to
respond to a user closing the window. This event is then passed on to
the LibCore event loop, which allows the application quit itself.
Previously the application would hang, only running in the background,
until killed by an external force.