### PR TITLE
Tabbed browsing support

### DIFF
--- a/BrowserWindow.cpp
+++ b/BrowserWindow.cpp
@@ -29,6 +29,7 @@ BrowserWindow::BrowserWindow(Core::EventLoop& event_loop)
         setWindowTitle(m_tabs_container->tabText(index));
         setWindowIcon(m_tabs_container->tabIcon(index));
     });
+    QObject::connect(m_tabs_container, &QTabWidget::tabCloseRequested, this, &BrowserWindow::close_tab);
 
     new_tab();
 
@@ -46,9 +47,19 @@ void BrowserWindow::new_tab()
     }
 
     m_tabs_container->addTab(tab_ptr, "New Tab");
+    m_tabs_container->setCurrentWidget(tab_ptr);
 
     QObject::connect(tab_ptr, &Tab::title_changed, this, &BrowserWindow::tab_title_changed);
     QObject::connect(tab_ptr, &Tab::favicon_changed, this, &BrowserWindow::tab_favicon_changed);
+}
+
+void BrowserWindow::close_tab(int index)
+{
+    auto* tab = m_tabs_container->widget(index);
+    m_tabs_container->removeTab(index);
+    m_tabs.remove_first_matching([&](auto& entry) {
+        return entry == tab;
+    });
 }
 
 int BrowserWindow::tab_index(Tab* tab)

--- a/BrowserWindow.h
+++ b/BrowserWindow.h
@@ -5,7 +5,7 @@
  */
 
 #include "Tab.h"
-#include <AK/Vector.h>
+#include <AK/NonnullOwnPtrVector.h>
 #include <LibCore/Forward.h>
 #include <QIcon>
 #include <QLineEdit>
@@ -33,10 +33,11 @@ public slots:
     void tab_title_changed(int index, QString const&);
     void tab_favicon_changed(int index, QIcon icon);
     void new_tab();
+    void close_tab(int index);
 
 private:
     QTabWidget* m_tabs_container { nullptr };
-    Vector<NonnullOwnPtr<Tab>> m_tabs;
+    NonnullOwnPtrVector<Tab> m_tabs;
     Tab* m_current_tab { nullptr };
 
     Core::EventLoop& m_event_loop;

--- a/BrowserWindow.h
+++ b/BrowserWindow.h
@@ -1,7 +1,17 @@
-#include <QIcon>
+/*
+ * Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Tab.h"
+#include <AK/Vector.h>
 #include <LibCore/Forward.h>
+#include <QIcon>
 #include <QLineEdit>
 #include <QMainWindow>
+#include <QMenuBar>
+#include <QTabWidget>
 #include <QToolBar>
 
 #pragma once
@@ -13,21 +23,21 @@ class BrowserWindow : public QMainWindow {
 public:
     explicit BrowserWindow(Core::EventLoop&);
 
-    WebView& view() { return *m_view; }
+    WebView& view() const { return m_current_tab->view(); }
+
+    int tab_index(Tab*);
 
     virtual void closeEvent(QCloseEvent*) override;
 
 public slots:
-    void location_edit_return_pressed();
-    void page_title_changed(QString);
-    void page_favicon_changed(QIcon);
-
-public slots:
-    void reload();
+    void tab_title_changed(int index, QString const&);
+    void tab_favicon_changed(int index, QIcon icon);
+    void new_tab();
 
 private:
-    QToolBar* m_toolbar { nullptr };
-    QLineEdit* m_location_edit { nullptr };
-    WebView* m_view { nullptr };
+    QTabWidget* m_tabs_container { nullptr };
+    Vector<NonnullOwnPtr<Tab>> m_tabs;
+    Tab* m_current_tab { nullptr };
+
     Core::EventLoop& m_event_loop;
 };

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SOURCES
     RequestManagerQt.cpp
     main.cpp
     WebView.cpp
+    Tab.cpp
 )
 
 add_executable(ladybird ${SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SOURCES
     RequestManagerQt.cpp
     main.cpp
     WebView.cpp
+    History.cpp
     Tab.cpp
 )
 

--- a/History.cpp
+++ b/History.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "History.h"
+
+namespace Browser {
+
+void History::dump() const
+{
+    dbgln("Dump {} items(s)", m_items.size());
+    int i = 0;
+    for (auto& item : m_items) {
+        dbgln("[{}] {} '{}' {}", i, item.url, item.title, m_current == i ? '*' : ' ');
+        ++i;
+    }
+}
+
+void History::push(const URL& url, String const& title)
+{
+    if (!m_items.is_empty() && m_items[m_current].url == url)
+        return;
+    m_items.shrink(m_current + 1);
+    m_items.append(URLTitlePair {
+        .url = url,
+        .title = title,
+    });
+    m_current++;
+}
+
+History::URLTitlePair History::current() const
+{
+    if (m_current == -1)
+        return {};
+    return m_items[m_current];
+}
+
+void History::go_back(int steps)
+{
+    VERIFY(can_go_back(steps));
+    m_current -= steps;
+}
+
+void History::go_forward(int steps)
+{
+    VERIFY(can_go_forward(steps));
+    m_current += steps;
+}
+
+void History::clear()
+{
+    m_items = {};
+    m_current = -1;
+}
+
+void History::update_title(String const& title)
+{
+    m_items[m_current].title = title;
+}
+
+Vector<StringView> History::get_back_title_history()
+{
+    Vector<StringView> back_title_history;
+    for (int i = m_current - 1; i >= 0; i--) {
+        back_title_history.append(m_items[i].title);
+    }
+    return back_title_history;
+}
+
+Vector<StringView> History::get_forward_title_history()
+{
+    Vector<StringView> forward_title_history;
+    for (int i = m_current + 1; i < static_cast<int>(m_items.size()); i++) {
+        forward_title_history.append(m_items[i].title);
+    }
+    return forward_title_history;
+}
+
+}

--- a/History.h
+++ b/History.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/URL.h>
+#include <AK/Vector.h>
+
+namespace Browser {
+
+class History {
+public:
+    struct URLTitlePair {
+        URL url;
+        String title;
+    };
+    void dump() const;
+
+    void push(const URL& url, String const& title);
+    void update_title(String const& title);
+    URLTitlePair current() const;
+
+    Vector<StringView> get_back_title_history();
+    Vector<StringView> get_forward_title_history();
+
+    void go_back(int steps = 1);
+    void go_forward(int steps = 1);
+
+    bool can_go_back(int steps = 1) { return (m_current - steps) >= 0; }
+    bool can_go_forward(int steps = 1) { return (m_current + steps) < static_cast<int>(m_items.size()); }
+    void clear();
+
+private:
+    Vector<URLTitlePair> m_items;
+    int m_current { -1 };
+};
+
+}

--- a/Tab.cpp
+++ b/Tab.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Matthew Costa <ucosty@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Tab.h"
+#include "BrowserWindow.h"
+#include <QCoreApplication>
+#include <QStatusBar>
+#include <utility>
+
+extern String s_serenity_resource_root;
+
+Tab::Tab(QMainWindow* window)
+    : m_window(window)
+{
+    m_layout = new QBoxLayout(QBoxLayout::Direction::TopToBottom, this);
+    m_layout->setContentsMargins(0, 0, 0, 0);
+
+    m_view = new WebView;
+    m_toolbar = new QToolBar;
+    m_location_edit = new QLineEdit;
+
+    m_layout->addWidget(m_toolbar);
+    m_layout->addWidget(m_view);
+
+    auto reload_icon_path = QString("%1/res/icons/16x16/reload.png").arg(s_serenity_resource_root.characters());
+    auto* reload_action = new QAction(QIcon(reload_icon_path), "Reload");
+    reload_action->setShortcut(QKeySequence("Ctrl+R"));
+    m_toolbar->addAction(reload_action);
+    m_toolbar->addWidget(m_location_edit);
+
+    QObject::connect(m_view, &WebView::linkHovered, m_window->statusBar(), &QStatusBar::showMessage);
+    QObject::connect(m_view, &WebView::linkUnhovered, m_window->statusBar(), &QStatusBar::clearMessage);
+
+    QObject::connect(m_view, &WebView::loadStarted, m_location_edit, &QLineEdit::setText);
+    QObject::connect(m_location_edit, &QLineEdit::returnPressed, this, &Tab::location_edit_return_pressed);
+    QObject::connect(m_view, &WebView::title_changed, this, &Tab::page_title_changed);
+    QObject::connect(m_view, &WebView::favicon_changed, this, &Tab::page_favicon_changed);
+
+    QObject::connect(reload_action, &QAction::triggered, this, &Tab::reload);
+}
+
+void Tab::reload()
+{
+    view().reload();
+}
+
+void Tab::location_edit_return_pressed()
+{
+    view().load(m_location_edit->text().toUtf8().data());
+}
+
+void Tab::page_title_changed(QString title)
+{
+    emit title_changed(tab_index(), std::move(title));
+}
+
+void Tab::page_favicon_changed(QIcon icon)
+{
+    emit favicon_changed(tab_index(), std::move(icon));
+}
+
+int Tab::tab_index()
+{
+    // FIXME: I hear you like footguns...
+    //        There has to be a better way of doing this
+    auto browser_window = reinterpret_cast<BrowserWindow *>(m_window);
+    return browser_window->tab_index(this);
+}

--- a/Tab.cpp
+++ b/Tab.cpp
@@ -7,9 +7,9 @@
 
 #include "Tab.h"
 #include "BrowserWindow.h"
+#include "History.h"
 #include <QCoreApplication>
 #include <QStatusBar>
-#include <utility>
 
 extern String s_serenity_resource_root;
 
@@ -26,21 +26,67 @@ Tab::Tab(QMainWindow* window)
     m_layout->addWidget(m_toolbar);
     m_layout->addWidget(m_view);
 
+    auto back_icon_path = QString("%1/res/icons/16x16/go-back.png").arg(s_serenity_resource_root.characters());
+    auto forward_icon_path = QString("%1/res/icons/16x16/go-forward.png").arg(s_serenity_resource_root.characters());
+    auto home_icon_path = QString("%1/res/icons/16x16/go-home.png").arg(s_serenity_resource_root.characters());
     auto reload_icon_path = QString("%1/res/icons/16x16/reload.png").arg(s_serenity_resource_root.characters());
-    auto* reload_action = new QAction(QIcon(reload_icon_path), "Reload");
-    reload_action->setShortcut(QKeySequence("Ctrl+R"));
-    m_toolbar->addAction(reload_action);
+    m_back_action = make<QAction>(QIcon(back_icon_path), "Back");
+    m_back_action->setShortcut(QKeySequence("Alt+Left"));
+    m_forward_action = make<QAction>(QIcon(forward_icon_path), "Forward");
+    m_forward_action->setShortcut(QKeySequence("Alt+Right"));
+    m_home_action = make<QAction>(QIcon(home_icon_path), "Home");
+    m_reload_action = make<QAction>(QIcon(reload_icon_path), "Reload");
+    m_reload_action->setShortcut(QKeySequence("Ctrl+R"));
+
+    m_toolbar->addAction(m_back_action);
+    m_toolbar->addAction(m_forward_action);
+    m_toolbar->addAction(m_reload_action);
+    m_toolbar->addAction(m_home_action);
     m_toolbar->addWidget(m_location_edit);
 
     QObject::connect(m_view, &WebView::linkHovered, m_window->statusBar(), &QStatusBar::showMessage);
     QObject::connect(m_view, &WebView::linkUnhovered, m_window->statusBar(), &QStatusBar::clearMessage);
 
-    QObject::connect(m_view, &WebView::loadStarted, m_location_edit, &QLineEdit::setText);
+    QObject::connect(m_view, &WebView::loadStarted, [this](const URL& url) {
+        m_location_edit->setText(url.to_string().characters());
+        m_history.push(url, m_title.toUtf8().data());
+    });
     QObject::connect(m_location_edit, &QLineEdit::returnPressed, this, &Tab::location_edit_return_pressed);
     QObject::connect(m_view, &WebView::title_changed, this, &Tab::page_title_changed);
     QObject::connect(m_view, &WebView::favicon_changed, this, &Tab::page_favicon_changed);
 
-    QObject::connect(reload_action, &QAction::triggered, this, &Tab::reload);
+    QObject::connect(m_back_action, &QAction::triggered, this, &Tab::back);
+    QObject::connect(m_forward_action, &QAction::triggered, this, &Tab::forward);
+    QObject::connect(m_home_action, &QAction::triggered, this, &Tab::home);
+    QObject::connect(m_reload_action, &QAction::triggered, this, &Tab::reload);
+}
+
+void Tab::navigate(const QString& url)
+{
+    view().load(url.toUtf8().data());
+}
+
+void Tab::back()
+{
+    if (!m_history.can_go_back())
+        return;
+
+    m_history.go_back();
+    view().load(m_history.current().url.to_string());
+}
+
+void Tab::forward()
+{
+    if (!m_history.can_go_forward())
+        return;
+
+    m_history.go_forward();
+    view().load(m_history.current().url.to_string());
+}
+
+void Tab::home()
+{
+    navigate("https://www.serenityos.org/");
 }
 
 void Tab::reload()
@@ -50,11 +96,12 @@ void Tab::reload()
 
 void Tab::location_edit_return_pressed()
 {
-    view().load(m_location_edit->text().toUtf8().data());
+    navigate(m_location_edit->text());
 }
 
 void Tab::page_title_changed(QString title)
 {
+    m_title = title;
     emit title_changed(tab_index(), std::move(title));
 }
 

--- a/Tab.cpp
+++ b/Tab.cpp
@@ -67,6 +67,6 @@ int Tab::tab_index()
 {
     // FIXME: I hear you like footguns...
     //        There has to be a better way of doing this
-    auto browser_window = reinterpret_cast<BrowserWindow *>(m_window);
+    auto browser_window = reinterpret_cast<BrowserWindow*>(m_window);
     return browser_window->tab_index(this);
 }

--- a/Tab.h
+++ b/Tab.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Matthew Costa <ucosty@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "WebView.h"
+#include <QBoxLayout>
+#include <QLineEdit>
+#include <QToolBar>
+#include <QWidget>
+
+class Tab final : public QWidget {
+    Q_OBJECT
+public:
+    explicit Tab(QMainWindow* window);
+
+    WebView& view() { return *m_view; }
+
+public slots:
+    void location_edit_return_pressed();
+    void page_title_changed(QString);
+    void page_favicon_changed(QIcon);
+    void reload();
+
+signals:
+    void title_changed(int id, QString);
+    void favicon_changed(int id, QIcon);
+
+private:
+    QBoxLayout* m_layout;
+    QToolBar* m_toolbar { nullptr };
+    QLineEdit* m_location_edit { nullptr };
+    WebView* m_view { nullptr };
+    QMainWindow* m_window { nullptr };
+
+    int tab_index();
+};

--- a/Tab.h
+++ b/Tab.h
@@ -7,6 +7,9 @@
 
 #pragma once
 
+#define AK_DONT_REPLACE_STD
+
+#include "History.h"
 #include "WebView.h"
 #include <QBoxLayout>
 #include <QLineEdit>
@@ -20,10 +23,15 @@ public:
 
     WebView& view() { return *m_view; }
 
+    void navigate(const QString&);
+
 public slots:
     void location_edit_return_pressed();
     void page_title_changed(QString);
     void page_favicon_changed(QIcon);
+    void back();
+    void forward();
+    void home();
     void reload();
 
 signals:
@@ -36,6 +44,13 @@ private:
     QLineEdit* m_location_edit { nullptr };
     WebView* m_view { nullptr };
     QMainWindow* m_window { nullptr };
+    Browser::History m_history;
+    QString m_title;
+
+    OwnPtr<QAction> m_back_action;
+    OwnPtr<QAction> m_forward_action;
+    OwnPtr<QAction> m_home_action;
+    OwnPtr<QAction> m_reload_action;
 
     int tab_index();
 };

--- a/WebView.cpp
+++ b/WebView.cpp
@@ -148,7 +148,7 @@ public:
 
     virtual void page_did_start_loading(AK::URL const& url) override
     {
-        emit m_view.loadStarted(url.to_string().characters());
+        emit m_view.loadStarted(url);
     }
 
     virtual void page_did_finish_loading(AK::URL const&) override

--- a/WebView.h
+++ b/WebView.h
@@ -33,7 +33,7 @@ public:
 signals:
     void linkHovered(QString, int timeout = 0);
     void linkUnhovered();
-    void loadStarted(QString);
+    void loadStarted(const URL&);
     void title_changed(QString);
     void favicon_changed(QIcon);
 


### PR DESCRIPTION
This patch removes the browser WebView from the window and places it
inside a Tab object, all wrapped up in a QT tab control.

This patch takes the browser history code from the Serenity browser and
wires it up to the QT interface. This is tied in with a few extra
toolbar buttons associated with each tab.