### PR TITLE
Fix scroll bar and mouse wheel scrolling

### DIFF
--- a/WebView.cpp
+++ b/WebView.cpp
@@ -316,6 +316,9 @@ WebView::WebView()
     m_page_client->set_viewport_rect({ 0, 0, 800, 600 });
 
     m_inverse_pixel_scaling_ratio = 1.0 / devicePixelRatio();
+
+    verticalScrollBar()->setSingleStep(24);
+    horizontalScrollBar()->setSingleStep(24);
 }
 
 WebView::~WebView()

--- a/WebView.cpp
+++ b/WebView.cpp
@@ -248,7 +248,9 @@ public:
             content_size = enclosing_int_rect(layout_root->paint_box()->absolute_rect()).size();
 
         m_view.verticalScrollBar()->setMaximum(content_size.height() - m_viewport_rect.height());
+        m_view.verticalScrollBar()->setPageStep(m_viewport_rect.height());
         m_view.horizontalScrollBar()->setMaximum(content_size.width() - m_viewport_rect.width());
+        m_view.horizontalScrollBar()->setPageStep(m_viewport_rect.width());
     }
 
     virtual void page_did_request_scroll_into_view(Gfx::IntRect const&) override


### PR DESCRIPTION
 Set singleStep for scroll bars in WebView
 - Sets singleStep to 24px, this allows you to scroll using your mouse scroll wheel :^)

Set pageStep for scroll bars in WebView
- This allows PageUp/PageDown keys to scroll 1 viewport size at a time.
- This also fixes the scroll bar drag handle to be a correct length.