### PR TITLE
Add support for Google Search in Address Bar

### DIFF
--- a/Tab.cpp
+++ b/Tab.cpp
@@ -42,6 +42,8 @@ Tab::Tab(QMainWindow* window)
     m_reload_action = make<QAction>(QIcon(reload_icon_path), "Reload");
     m_reload_action->setShortcut(QKeySequence("Ctrl+R"));
 
+    m_location_edit->setPlaceholderText("Search with Google or enter address");
+
     m_toolbar->addAction(m_back_action);
     m_toolbar->addAction(m_forward_action);
     m_toolbar->addAction(m_reload_action);
@@ -102,7 +104,14 @@ void Tab::reload()
 
 void Tab::location_edit_return_pressed()
 {
-    navigate(m_location_edit->text());
+    QString user_input = m_location_edit->text();
+
+    if (!user_input.startsWith("http") && !user_input.startsWith("https")) {
+        // TODO: add more Search providers
+        user_input.prepend("https://google.com/search?q=");
+    }
+
+    navigate(user_input);
 }
 
 void Tab::page_title_changed(QString title)

--- a/Tab.cpp
+++ b/Tab.cpp
@@ -42,7 +42,7 @@ Tab::Tab(QMainWindow* window)
     m_reload_action = make<QAction>(QIcon(reload_icon_path), "Reload");
     m_reload_action->setShortcut(QKeySequence("Ctrl+R"));
 
-    m_location_edit->setPlaceholderText("Search with Google or enter address");
+    m_location_edit->setPlaceholderText("Search with Brave or enter address");
 
     m_toolbar->addAction(m_back_action);
     m_toolbar->addAction(m_forward_action);
@@ -108,7 +108,7 @@ void Tab::location_edit_return_pressed()
 
     if (!user_input.startsWith("http") && !user_input.startsWith("https")) {
         // TODO: add more Search providers
-        user_input.prepend("https://google.com/search?q=");
+        user_input.prepend("https://search.brave.com/search?q=");
     }
 
     navigate(user_input);


### PR DESCRIPTION
This commit adds support for to search for anything within the address bar using Google Search just like a web browser should.

I've also added placeholder text to `QLineEdit` to indicate this to user.

### Note

I went with Google as the browser was showing search results. This wasn't possible with Bing or with DuckDuckGo.