### PR TITLE
Add support for Qt5

### DIFF
--- a/BrowserWindow.cpp
+++ b/BrowserWindow.cpp
@@ -27,18 +27,18 @@ BrowserWindow::BrowserWindow(Core::EventLoop& event_loop)
     auto* menu = menuBar()->addMenu("&File");
 
     auto* new_tab_action = new QAction("New &Tab");
-    new_tab_action->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_T));
+    new_tab_action->setShortcut(QKeySequence("Ctrl+T"));
     menu->addAction(new_tab_action);
 
     auto* quit_action = new QAction("&Quit");
-    quit_action->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_Q));
+    quit_action->setShortcut(QKeySequence("Ctrl+Q"));
     menu->addAction(quit_action);
 
     auto* inspect_menu = menuBar()->addMenu("&Inspect");
 
     auto* view_source_action = new QAction("View &Source");
     view_source_action->setIcon(QIcon(QString("%1/res/icons/16x16/filetype-html.png").arg(s_serenity_resource_root.characters())));
-    view_source_action->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_U));
+    view_source_action->setShortcut(QKeySequence("CTRL + U"));
     inspect_menu->addAction(view_source_action);
     QObject::connect(view_source_action, &QAction::triggered, this, [this] {
         if (m_current_tab) {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,9 @@ add_compile_options(-Wno-expansion-to-defined)
 add_compile_options(-Wno-user-defined-literals)
 
 set(CMAKE_AUTOMOC ON)
-find_package(Qt6 REQUIRED COMPONENTS Core Widgets Network)
+
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core Gui Network Widgets REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Gui Network Widgets )
 
 set(SOURCES
     BrowserWindow.cpp
@@ -44,7 +46,7 @@ set(SOURCES
 )
 
 add_executable(ladybird ${SOURCES})
-target_link_libraries(ladybird PRIVATE Qt6::Widgets Qt::Network Lagom::Web Lagom::WebSocket Lagom::Main)
+target_link_libraries(ladybird PRIVATE Qt::Widgets Qt::Network Lagom::Web Lagom::WebSocket Lagom::Main)
 
 get_filename_component(
     SERENITY_SOURCE_DIR "${Lagom_SOURCE_DIR}/../.."

--- a/WebView.cpp
+++ b/WebView.cpp
@@ -376,7 +376,11 @@ unsigned get_modifiers_from_qt_event(QMouseEvent const& event)
 
 void WebView::mouseMoveEvent(QMouseEvent* event)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     Gfx::IntPoint position(event->position().x() / m_inverse_pixel_scaling_ratio, event->position().y() / m_inverse_pixel_scaling_ratio);
+#else
+    Gfx::IntPoint position(event->x() / m_inverse_pixel_scaling_ratio, event->y() / m_inverse_pixel_scaling_ratio);
+#endif
     auto buttons = get_buttons_from_qt_event(*event);
     auto modifiers = get_modifiers_from_qt_event(*event);
     m_page_client->page().handle_mousemove(to_content(position), buttons, modifiers);
@@ -384,7 +388,11 @@ void WebView::mouseMoveEvent(QMouseEvent* event)
 
 void WebView::mousePressEvent(QMouseEvent* event)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     Gfx::IntPoint position(event->position().x() / m_inverse_pixel_scaling_ratio, event->position().y() / m_inverse_pixel_scaling_ratio);
+#else
+    Gfx::IntPoint position(event->x() / m_inverse_pixel_scaling_ratio, event->y() / m_inverse_pixel_scaling_ratio);
+#endif
     auto button = get_button_from_qt_event(*event);
     auto modifiers = get_modifiers_from_qt_event(*event);
     m_page_client->page().handle_mousedown(to_content(position), button, modifiers);
@@ -392,7 +400,11 @@ void WebView::mousePressEvent(QMouseEvent* event)
 
 void WebView::mouseReleaseEvent(QMouseEvent* event)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     Gfx::IntPoint position(event->position().x() / m_inverse_pixel_scaling_ratio, event->position().y() / m_inverse_pixel_scaling_ratio);
+#else
+    Gfx::IntPoint position(event->x() / m_inverse_pixel_scaling_ratio, event->y() / m_inverse_pixel_scaling_ratio);
+#endif
     auto button = get_button_from_qt_event(*event);
     auto modifiers = get_modifiers_from_qt_event(*event);
     m_page_client->page().handle_mouseup(to_content(position), button, modifiers);


### PR DESCRIPTION
As on Debian by default we still have Qt5 and  FreeBSD has similar problem (? not a real problem...)

Lets back-port the code to Qt5. There is only a single part where code differs, and this is a
very small hairy part... I am quite happy about the compatibility between both versions.

This should help with https://github.com/awesomekling/ladybird/issues/19 