### PR TITLE
Add a protocol to the URL, when one is not set

### DIFF
--- a/Tab.cpp
+++ b/Tab.cpp
@@ -73,8 +73,11 @@ Tab::Tab(QMainWindow* window)
     QObject::connect(focus_location_edit_action, &QAction::triggered, m_location_edit, &QLineEdit::selectAll);
 }
 
-void Tab::navigate(QString const& url)
+void Tab::navigate(QString url)
 {
+    if (!url.startsWith("http://", Qt::CaseInsensitive) &&
+        !url.startsWith("https://", Qt::CaseInsensitive))
+        url = "http://" + url;
     view().load(url.toUtf8().data());
 }
 

--- a/Tab.h
+++ b/Tab.h
@@ -23,7 +23,7 @@ public:
 
     WebView& view() { return *m_view; }
 
-    void navigate(QString const&);
+    void navigate(QString);
 
     void debug_request(String const& request, String const& argument);
 


### PR DESCRIPTION
When a http(s):// is not written by the user - lets manually add one.

(PS: why is gemini support missing from the library?)