### PR TITLE
Meta: use reverse domain name notation in property list files

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -15,7 +15,7 @@
         <key>CFBundleExecutable</key>
         <string>Ladybird</string>
         <key>CFBundleIdentifier</key>
-        <string>com.serenity.Ladybird</string>
+        <string>org.SerenityOS.Ladybird</string>
         <key>NSPrincipalClass</key>
         <string>NSApplication</string>
         <key>NSHighResolutionCapable</key>


### PR DESCRIPTION
I think the recommended approach to bundle identifier is using reverse domain name notation.

This PR should be reviewed by @filiphsps before merged.